### PR TITLE
Remove global variable `meta`

### DIFF
--- a/src/verilog_ast.c
+++ b/src/verilog_ast.c
@@ -2840,7 +2840,7 @@ ast_number * ast_new_number(
 
     tr -> base = base;
     tr -> representation = representation;
-    tr -> as_bits = digits;
+    tr -> as_bits = ast_strdup(digits);
 
     return tr;
 }

--- a/src/verilog_ast.h
+++ b/src/verilog_ast.h
@@ -1092,7 +1092,6 @@ typedef enum ast_event_expression_type_e{
 
 //! Describes a single event expression
 typedef struct ast_event_expression_t ast_event_expression;
-    ast_metadata    meta;   //!< Node metadata.
 struct ast_event_expression_t {
     ast_event_expression_type type;
     union{

--- a/src/verilog_parser.y
+++ b/src/verilog_parser.y
@@ -1137,19 +1137,19 @@ port_declaration_l:
     ast_list * names = ast_list_new();
     ast_list_append(names, $4);
     $$ = ast_new_port_declaration(PORT_NONE, $1, $2,
-    AST_FALSE,AST_FALSE,NULL,names);
+    AST_FALSE,AST_FALSE,$3,names);
 }
 |            signed_o range_o port_identifier{
     ast_list * names = ast_list_new();
     ast_list_append(names, $3);
     $$ = ast_new_port_declaration(PORT_NONE, NET_TYPE_NONE, $1,
-    AST_FALSE,AST_FALSE,NULL,names);
+    AST_FALSE,AST_FALSE,$2,names);
 }
 | KW_REG     signed_o range_o port_identifier eq_const_exp_o{
     ast_list * names = ast_list_new();
     ast_list_append(names, $4);
     $$ = ast_new_port_declaration(PORT_NONE, NET_TYPE_NONE, AST_FALSE,
-    AST_TRUE,AST_FALSE,NULL,names);
+    AST_TRUE,AST_FALSE,$3,names);
 }
 | output_variable_type_o      port_identifier{
     ast_list * names = ast_list_new();


### PR DESCRIPTION
 - Remove global variable `meta` which is unused
 - Store range info in ast_port_declaration
 - Copy `as_bits` field to avoid being changed


### List of changes

- src/verilog_ast.h: remove meta from line 1092
- src/verilog_parser.y : use `range_o` to replace NULL for non-terminal: port_declaration_l 
- src/verilog_ast.c: use ast_strdup in function `ast_new_number`

## Fixes:

- Now it is fine for others to include the headers in multiple source files.
- `ast_number->as_bits` are usable
- Range can be obtained in `ast_port_declaration` (for new style module declaration)

