### PR TITLE
fix memory management bookkeeping issue

### DIFF
--- a/src/verilog_ast_mem.c
+++ b/src/verilog_ast_mem.c
@@ -55,7 +55,7 @@ void * ast_calloc(size_t num, size_t size)
     {
         walker -> next = calloc(1,sizeof(ast_memory));
         walker -> next -> size = num * size;
-        total_allocated += walker -> size;
+        total_allocated += walker -> next -> size;
         walker -> next -> data = data;
         walker -> next -> next = NULL;
         walker         = walker -> next;
@@ -91,6 +91,7 @@ void ast_free_all()
     printf("\tFree'd %lu bytes of %lu bytes allocated.\n", 
         total_freed, total_allocated);
     printf("\tBytes remaining: %lu\n", total_allocated - total_freed);
+    total_allocated -= total_freed;
 }
 
 


### PR DESCRIPTION
## Purpose

fix memory management accounting issue

### List of changes

- verilog_ast_mem.c: counting the size using the correct block size.
- verilog_ast_mem.c: deduct the freed bytes from `total_allocated` when freed. So the bookkeeping is reusable.

