### PR TITLE
Possible fix for issue #23

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -19,17 +19,17 @@ int main(int argc, char ** argv)
     }
     else
     {
+
         int F = 0;
-            
-        // Initialise the parser.
-        verilog_parser_init();
-
-        // Setup the preprocessor to look in ./tests/ for include files.
-        ast_list_append(yy_preproc -> search_dirs, "./tests/");
-        ast_list_append(yy_preproc -> search_dirs, "./");
-
         for(F = 1; F < argc; F++)
         {
+            
+            // Initialise the parser.
+            verilog_parser_init();
+
+            // Setup the preprocessor to look in ./tests/ for include files.
+            ast_list_append(yy_preproc -> search_dirs, "./tests/");
+            ast_list_append(yy_preproc -> search_dirs, "./");
             printf("%s ", argv[F]);fflush(stdout);
 
             // Load the file.
@@ -52,9 +52,9 @@ int main(int argc, char ** argv)
                 printf(" - Parse failed\n");
                 if(argc<=2) return 1;
             }
+
+            verilog_resolve_modules(yy_verilog_source_tree);
         }
     }
-    verilog_resolve_modules(yy_verilog_source_tree);
-    ast_free_all();
     return 0;
 }

--- a/src/verilog_parser_wrapper.c
+++ b/src/verilog_parser_wrapper.c
@@ -12,16 +12,8 @@ extern int yyparse();
 
 void    verilog_parser_init()
 {
-    if(yy_preproc == NULL) 
-    {
-        //printf("Added new preprocessor context\n");
-        yy_preproc = verilog_new_preprocessor_context();
-    }
-    if(yy_verilog_source_tree == NULL)
-    {
-        //printf("Added new source tree\n");
-        yy_verilog_source_tree = verilog_new_source_tree();
-    }
+    yy_preproc = verilog_new_preprocessor_context();
+    yy_verilog_source_tree = verilog_new_source_tree();
 }
 
 /*!

--- a/src/verilog_preprocessor.c
+++ b/src/verilog_preprocessor.c
@@ -228,6 +228,10 @@ void verilog_preprocessor_macro_define(
 
     //printf("MACRO: '%s' - '%s'\n", toadd -> macro_id, toadd -> macro_value);
 
+    // Set source file of the macro
+    char * current_file = verilog_preprocessor_current_file(yy_preproc);
+    toadd -> src_file   = ast_strdup(current_file);
+
     ast_hashtable_insert(
         yy_preproc -> macrodefines,
         toadd -> macro_id,
@@ -243,6 +247,7 @@ void verilog_preprocessor_macro_define(
 void verilog_preprocessor_macro_undefine(
     char * macro_name //!< The name of the macro to remove.
 ){
+
     ast_hashtable_delete(
         yy_preproc -> macrodefines,
         macro_name

--- a/src/verilog_preprocessor.h
+++ b/src/verilog_preprocessor.h
@@ -109,6 +109,7 @@ typedef struct verilog_macro_directive_t{
     unsigned int line;      //!< Line number of the directive.
     char * macro_id;        //!< The name of the macro.
     char * macro_value;     //!< The value it expands to.
+    char * src_file;        //!< Source file containing the macro definition
 } verilog_macro_directive;
 
 /*!

--- a/src/verilog_scanner.l
+++ b/src/verilog_scanner.l
@@ -529,6 +529,9 @@ TERNARY             "?"
         YY_BUFFER_STATE cur = YY_CURRENT_BUFFER;
         YY_BUFFER_STATE n   = yy_scan_string(macro -> macro_value);
         
+        // Set the "current file" to the one the macro was defined in.
+        ast_stack_push(yy_preproc -> current_file, macro -> src_file);
+
         yy_switch_to_buffer(cur);
         yypush_buffer_state(n);
     }


### PR DESCRIPTION
## Purpose (WIP)

- make source of currently expanding macro easier to determine
- fix #23  - inballanced `yy_preproc -> current_file` stack pointed out by @zhanghongce 

### List of changes

- Include source file in macro descriptions
- Push file where macro was defined to yy_preprec->current_file stack
  to prevent underflow when returning from multiple defines (see #23 for
  problem details).

## Fixes:

- fix #23 
